### PR TITLE
Make Maven Command Line Arguments for API Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # STEP 2020 Capstone project
 
 Our objective is to provide users with relevant news and action-initiatives based on their interests We want users to be able to deeply understand topics related to their interests (as indicated by their social media activity) and have the resources to take action.
+
+# How To Run
+For security purposes, the API keys used in this applicaiton must be passed as command line arguments.
+To run, use the following command: 	`[mvn command] -DbooksKey=[Google Books API Key] -DprojectsKey=[Global Giving API Key] -DcivicsKey=[Google Civics API Key] -DlocationKey=[Google Geocoder API Key]`

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Our objective is to provide users with relevant news and action-initiatives base
 
 # How To Run
 For security purposes, the API keys used in this applicaiton must be passed as command line arguments.
-To run, use the following command: 	`[mvn command] -DbooksKey=[Google Books API Key] -DprojectsKey=[Global Giving API Key] -DcivicsKey=[Google Civics API Key] -DlocationKey=[Google Geocoder API Key]`
+To run, use the following command: 	`[mvn command] -DgoogleKey=[Key for Google APIs] -DprojectsKey=[Global Giving API Key]`

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>
-    <testParam>${testParam}</testParam>
+    <booksKey>${booksKey}</booksKey>
+    <projectsKey>${projectsKey}</projectsKey>
+    <civicsKey>${civicsKey}</civicsKey>
+    <locationKey>${locationKey}</locationKey>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>
-    <booksKey>${booksKey}</booksKey>
+    <googleKey>${googleKey}</googleKey>
     <projectsKey>${projectsKey}</projectsKey>
-    <civicsKey>${civicsKey}</civicsKey>
-    <locationKey>${locationKey}</locationKey>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>
+    <testParam>${testParam}</testParam>
   </properties>
 
   <dependencies>
@@ -73,6 +74,7 @@
     <resources>
       <resource>
         <directory>src/main/resources</directory>
+        <filtering>true</filtering>
       </resource>
       <resource>
         <directory>src/main/webapp/templates</directory>

--- a/src/main/java/com/google/sps/data/GetAPIKeyUtil.java
+++ b/src/main/java/com/google/sps/data/GetAPIKeyUtil.java
@@ -6,12 +6,11 @@ import java.io.IOException;
 
 public class GetAPIKeyUtil {
 
-  public String getAPIKey(String api) throws IOException {
+  public String getAPIKey(String apiName) throws IOException {
     System.out.println("in getAPIKey");
     Properties properties = new Properties();
     properties.load(GetAPIKeyUtil.class.getClassLoader().getResourceAsStream("project.properties"));  
-    return properties.getProperty("testParam");
-    //return properties.getProperty(api + "Key");
+    return properties.getProperty(apiName + "Key");
   }
 
 }

--- a/src/main/java/com/google/sps/data/GetAPIKeyUtil.java
+++ b/src/main/java/com/google/sps/data/GetAPIKeyUtil.java
@@ -1,0 +1,17 @@
+package com.google.sps.data;
+
+import java.io.InputStream;
+import java.util.Properties;
+import java.io.IOException;
+
+public class GetAPIKeyUtil {
+
+  public String getAPIKey(String api) throws IOException {
+    System.out.println("in getAPIKey");
+    Properties properties = new Properties();
+    properties.load(GetAPIKeyUtil.class.getClassLoader().getResourceAsStream("project.properties"));  
+    return properties.getProperty("testParam");
+    //return properties.getProperty(api + "Key");
+  }
+
+}

--- a/src/main/java/com/google/sps/data/GetAPIKeyUtil.java
+++ b/src/main/java/com/google/sps/data/GetAPIKeyUtil.java
@@ -7,10 +7,8 @@ import java.io.IOException;
 public class GetAPIKeyUtil {
 
   public String getAPIKey(String apiName) throws IOException {
-    System.out.println("in getAPIKey");
     Properties properties = new Properties();
     properties.load(GetAPIKeyUtil.class.getClassLoader().getResourceAsStream("project.properties"));  
     return properties.getProperty(apiName + "Key");
   }
-
 }

--- a/src/main/java/com/google/sps/servlets/BooksServlet.java
+++ b/src/main/java/com/google/sps/servlets/BooksServlet.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.sps.data.Book;
+import com.google.sps.data.GetAPIKeyUtil;
 import java.net.URL;
 import java.net.HttpURLConnection;
 import java.util.Scanner;
@@ -32,13 +33,18 @@ import java.util.Map;
 public class BooksServlet extends HttpServlet {
 
   private final int NUM_BOOKS_PER_TERM = 5;
-  private static final String API_KEY = "API_KEY";  // Insert the API_KEY here for testing.
+  private static final String API_KEY = "AIzaSyD7NSsRElnqx6MTVSIq0-lRYe2sl2nosAk";  // Insert the API_KEY here for testing.
 
   /*
   * Writes a mapping of terms to lists of book objects in the servlet response.
   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    System.out.println("line 43");
+    GetAPIKeyUtil util = new GetAPIKeyUtil();
+    System.out.println("line 45");
+    System.out.println("testParam is " + util.getAPIKey("books"));
+    System.out.println("line 47");
     List<String> terms = Arrays.asList(request.getParameterValues("key"));
     LinkedHashMap<String, List<Book>> booksMap = new LinkedHashMap<>();
     terms.forEach((term) -> {

--- a/src/main/java/com/google/sps/servlets/BooksServlet.java
+++ b/src/main/java/com/google/sps/servlets/BooksServlet.java
@@ -41,7 +41,7 @@ public class BooksServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     GetAPIKeyUtil util = new GetAPIKeyUtil();
-    API_KEY = util.getAPIKey("books");
+    API_KEY = util.getAPIKey("google");
     List<String> terms = Arrays.asList(request.getParameterValues("key"));
     LinkedHashMap<String, List<Book>> booksMap = new LinkedHashMap<>();
     terms.forEach((term) -> {

--- a/src/main/java/com/google/sps/servlets/BooksServlet.java
+++ b/src/main/java/com/google/sps/servlets/BooksServlet.java
@@ -33,18 +33,15 @@ import java.util.Map;
 public class BooksServlet extends HttpServlet {
 
   private final int NUM_BOOKS_PER_TERM = 5;
-  private static final String API_KEY = "AIzaSyD7NSsRElnqx6MTVSIq0-lRYe2sl2nosAk";  // Insert the API_KEY here for testing.
+  private String API_KEY = "";  // Insert the API_KEY here for testing.
 
   /*
   * Writes a mapping of terms to lists of book objects in the servlet response.
   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    System.out.println("line 43");
     GetAPIKeyUtil util = new GetAPIKeyUtil();
-    System.out.println("line 45");
-    System.out.println("testParam is " + util.getAPIKey("books"));
-    System.out.println("line 47");
+    API_KEY = util.getAPIKey("books");
     List<String> terms = Arrays.asList(request.getParameterValues("key"));
     LinkedHashMap<String, List<Book>> booksMap = new LinkedHashMap<>();
     terms.forEach((term) -> {

--- a/src/main/java/com/google/sps/servlets/BooksServlet.java
+++ b/src/main/java/com/google/sps/servlets/BooksServlet.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class BooksServlet extends HttpServlet {
 
   private final int NUM_BOOKS_PER_TERM = 5;
-  private String API_KEY = "";  // Insert the API_KEY here for testing.
+  private static String API_KEY;
 
   /*
   * Writes a mapping of terms to lists of book objects in the servlet response.

--- a/src/main/java/com/google/sps/servlets/LocationServlet.java
+++ b/src/main/java/com/google/sps/servlets/LocationServlet.java
@@ -4,6 +4,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.sps.data.GetAPIKeyUtil;
 import java.net.URL;
 import java.net.HttpURLConnection;
 import java.util.Scanner;
@@ -23,10 +24,12 @@ public class LocationServlet extends HttpServlet {
     private Map<String, String> geoMap = new HashMap<>();
 
     private static final String BASE_URL = "https://maps.googleapis.com/maps/api/geocode/json?";
-    private static final String API_KEY = "API_KEY"; // Insert actual API key to test.
+    private static String API_KEY = "API_KEY"; // Insert actual API key to test.
 
     @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) {
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+      GetAPIKeyUtil util = new GetAPIKeyUtil();
+      API_KEY = util.getAPIKey("location");
       String latitude = request.getParameter("lat");
       String longitude = request.getParameter("lng");
       String queryParam = String.format("latlng=%s,%s", latitude, longitude);

--- a/src/main/java/com/google/sps/servlets/LocationServlet.java
+++ b/src/main/java/com/google/sps/servlets/LocationServlet.java
@@ -24,7 +24,7 @@ public class LocationServlet extends HttpServlet {
     private Map<String, String> geoMap = new HashMap<>();
 
     private static final String BASE_URL = "https://maps.googleapis.com/maps/api/geocode/json?";
-    private static String API_KEY = "API_KEY"; // Insert actual API key to test.
+    private static String API_KEY;
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/src/main/java/com/google/sps/servlets/LocationServlet.java
+++ b/src/main/java/com/google/sps/servlets/LocationServlet.java
@@ -29,7 +29,7 @@ public class LocationServlet extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
       GetAPIKeyUtil util = new GetAPIKeyUtil();
-      API_KEY = util.getAPIKey("location");
+      API_KEY = util.getAPIKey("google");
       String latitude = request.getParameter("lat");
       String longitude = request.getParameter("lng");
       String queryParam = String.format("latlng=%s,%s", latitude, longitude);

--- a/src/main/java/com/google/sps/servlets/actions/CivicServlet.java
+++ b/src/main/java/com/google/sps/servlets/actions/CivicServlet.java
@@ -18,7 +18,7 @@ import com.google.sps.data.UrlRequest;
 @WebServlet("/actions/civic")
 public class CivicServlet extends HttpServlet {
 
-  private static String API_KEY = "API_KEY";  // Insert the API_KEY here for testing.
+  private static String API_KEY;
   private static final String API_PATH = "https://www.googleapis.com/civicinfo/v2/representatives";
 
   @Override

--- a/src/main/java/com/google/sps/servlets/actions/CivicServlet.java
+++ b/src/main/java/com/google/sps/servlets/actions/CivicServlet.java
@@ -24,7 +24,7 @@ public class CivicServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     GetAPIKeyUtil util = new GetAPIKeyUtil();
-    API_KEY = util.getAPIKey("civic");
+    API_KEY = util.getAPIKey("google");
     String latitude = request.getParameter("lat");
     String longitude = request.getParameter("lng");
     Map<String, String> locationQueryParams = new HashMap<>();

--- a/src/main/java/com/google/sps/servlets/actions/CivicServlet.java
+++ b/src/main/java/com/google/sps/servlets/actions/CivicServlet.java
@@ -4,6 +4,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.sps.data.GetAPIKeyUtil;
 import java.io.IOException;
 import java.io.FileNotFoundException;
 import java.util.Map;
@@ -17,11 +18,13 @@ import com.google.sps.data.UrlRequest;
 @WebServlet("/actions/civic")
 public class CivicServlet extends HttpServlet {
 
-  private static final String API_KEY = "API_KEY";  // Insert the API_KEY here for testing.
+  private static String API_KEY = "API_KEY";  // Insert the API_KEY here for testing.
   private static final String API_PATH = "https://www.googleapis.com/civicinfo/v2/representatives";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    GetAPIKeyUtil util = new GetAPIKeyUtil();
+    API_KEY = util.getAPIKey("civic");
     String latitude = request.getParameter("lat");
     String longitude = request.getParameter("lng");
     Map<String, String> locationQueryParams = new HashMap<>();

--- a/src/main/java/com/google/sps/servlets/actions/ProjectsServlet.java
+++ b/src/main/java/com/google/sps/servlets/actions/ProjectsServlet.java
@@ -4,6 +4,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.sps.data.GetAPIKeyUtil;
 import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
@@ -21,11 +22,13 @@ import com.google.sps.data.UrlRequest;
 @WebServlet("/actions/projects")
 public class ProjectsServlet extends HttpServlet {
 
-  private static final String API_KEY = "a752ec3e-9fcf-4500-9107-694351adc5ee";  // Insert the API_KEY here for testing.
+  private static String API_KEY = "";  // Insert the API_KEY here for testing.
   private static final String API_PATH = "https://api.globalgiving.org/api/public/services/search/projects";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    GetAPIKeyUtil util = new GetAPIKeyUtil();
+    API_KEY = util.getAPIKey("projects");
     String[] terms = request.getParameterValues("key");
     Map<String, List<Project>> jsonResultMap = new HashMap<>();
     Map<String, String> queryParams = new HashMap<>();

--- a/src/main/java/com/google/sps/servlets/actions/ProjectsServlet.java
+++ b/src/main/java/com/google/sps/servlets/actions/ProjectsServlet.java
@@ -21,7 +21,7 @@ import com.google.sps.data.UrlRequest;
 @WebServlet("/actions/projects")
 public class ProjectsServlet extends HttpServlet {
 
-  private static final String API_KEY = "API_KEY";  // Insert the API_KEY here for testing.
+  private static final String API_KEY = "a752ec3e-9fcf-4500-9107-694351adc5ee";  // Insert the API_KEY here for testing.
   private static final String API_PATH = "https://api.globalgiving.org/api/public/services/search/projects";
 
   @Override

--- a/src/main/java/com/google/sps/servlets/actions/ProjectsServlet.java
+++ b/src/main/java/com/google/sps/servlets/actions/ProjectsServlet.java
@@ -22,7 +22,7 @@ import com.google.sps.data.UrlRequest;
 @WebServlet("/actions/projects")
 public class ProjectsServlet extends HttpServlet {
 
-  private static String API_KEY = "";  // Insert the API_KEY here for testing.
+  private static String API_KEY;
   private static final String API_PATH = "https://api.globalgiving.org/api/public/services/search/projects";
 
   @Override

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,1 +1,4 @@
-testParam = ${testParam}
+booksKey = ${booksKey}
+projectsKey = ${projectsKey}
+civicsKey = ${civicsKey}
+locationKey = ${locationKey}

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,4 +1,2 @@
-booksKey = ${booksKey}
+googleKey = ${googleKey}
 projectsKey = ${projectsKey}
-civicsKey = ${civicsKey}
-locationKey = ${locationKey}

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,0 +1,1 @@
+testParam = ${testParam}


### PR DESCRIPTION
To not have to manually enter each API key each time to test, the API keys are passed as command line arguments. Check the readme for more instructions about how to use it.