### PR TITLE
Attempt text detection first before resorting to label detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <deploy.projectId>andrewhl-step-2020</deploy.projectId>
+          <deploy.projectId>step2020-team36-capstone</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <deploy.projectId>step2020-team36-capstone</deploy.projectId>
+          <deploy.projectId>andrewhl-step-2020</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/src/main/java/com/google/sps/servlets/ImageServlet.java
+++ b/src/main/java/com/google/sps/servlets/ImageServlet.java
@@ -148,7 +148,8 @@ public class ImageServlet extends HttpServlet {
     AnnotateImageResponse imageResponse = imageResponses.get(0);
 
     if (imageResponse.hasError()) {
-      System.err.println(String.format("Error getting image %s: %s ", (useTextDetection) ? "text" : "labels", imageResponse.getError().getMessage()));
+      String errorType = (useTextDetection) ? "text" : "labels";
+      System.err.println(String.format("Error getting image %s: %s ", errorType, imageResponse.getError().getMessage()));
       return null;
     }
     return imageResponse;

--- a/src/main/java/com/google/sps/servlets/ImageServlet.java
+++ b/src/main/java/com/google/sps/servlets/ImageServlet.java
@@ -134,9 +134,7 @@ public class ImageServlet extends HttpServlet {
   private AnnotateImageResponse getImageResponse(byte[] imgBytes, boolean useTextDetection) throws IOException {
     ByteString byteString = ByteString.copyFrom(imgBytes);
     Image image = Image.newBuilder().setContent(byteString).build();
-
     Feature.Type detectionMethod = (useTextDetection) ? Feature.Type.TEXT_DETECTION : Feature.Type.LABEL_DETECTION;
-
     Feature feature = Feature.newBuilder().setType(detectionMethod).build();
     AnnotateImageRequest request =
         AnnotateImageRequest.newBuilder().addFeatures(feature).setImage(image).build();

--- a/src/main/java/com/google/sps/servlets/ImageServlet.java
+++ b/src/main/java/com/google/sps/servlets/ImageServlet.java
@@ -148,7 +148,7 @@ public class ImageServlet extends HttpServlet {
     AnnotateImageResponse imageResponse = imageResponses.get(0);
 
     if (imageResponse.hasError()) {
-      System.err.println("Error getting image labels or text: " + imageResponse.getError().getMessage());
+      System.err.println(String.format("Error getting image %s: %s ", (useTextDetection) ? "text" : "labels", imageResponse.getError().getMessage()));
       return null;
     }
     return imageResponse;


### PR DESCRIPTION
There seems to be a small problem with the number of keywords that pop out from the text_detection as although it reads the whole text on the image (sometimes incorrectly), I think the threshold makes it so that a lot of the keywords don't end up showing up in the final returned list. So, I may need to re-adjust some of the thresholds as they were mainly for label detection and the likes, and text_detection seems to have slightly different results. Namely, a lot of the important keywords ended up having a salience of under 0.1 (like around 0.9), which voided them from the list.