### PR TITLE
Results block

### DIFF
--- a/src/main/webapp/scripts/toggle.js
+++ b/src/main/webapp/scripts/toggle.js
@@ -19,6 +19,11 @@ let loadingCounter;
  */
 async function loadContentSection() {
   const keywords = await loadKeywords(KEYWORDS_OBJ_URL);
+  if (keywords == null) {
+    $('#login-error').removeClass('hide');
+    hideLoading();
+    return;
+  }
   const elementsToLoad = Math.max(keywords.length, 1);
   counter.add(elementsToLoad);
   loadingCounter = traceCounterMethods(counter, elementsToLoad);

--- a/src/main/webapp/templates/results.html
+++ b/src/main/webapp/templates/results.html
@@ -31,6 +31,7 @@
         </div>
         <button id="log-btn" class="hide button"></button>
         <p id="title">Engage</p>
+        <p id="login-error" class="hide">You are not logged in!</p>
         <div id="progress-bar">
           <div id="bar"></div>
           <div id="progress"></div>


### PR DESCRIPTION
This should successfully block the results page from loading and popping up with the keywords when the user is not logged in.