### PR TITLE
Fixed single-quote formatting for news.

### DIFF
--- a/src/main/java/com/google/sps/servlets/NewsServlet.java
+++ b/src/main/java/com/google/sps/servlets/NewsServlet.java
@@ -126,6 +126,7 @@ public class NewsServlet extends HttpServlet {
       lastSubstring = substrings[i - 1];
       thisSubstring = substrings[i];
       title = thisSubstring.substring(thisSubstring.indexOf(">") + 1, thisSubstring.indexOf("<"));
+      // Replace single-quote encoding in titles with actual single quote.
       title = title.replace("&#39;", "'");
       linkElement = lastSubstring.substring(lastSubstring.lastIndexOf("href"), lastSubstring.lastIndexOf("\""));
       link = "http://news.google.com" + linkElement.substring(linkElement.indexOf(".") + 1, linkElement.lastIndexOf("\""));

--- a/src/main/java/com/google/sps/servlets/NewsServlet.java
+++ b/src/main/java/com/google/sps/servlets/NewsServlet.java
@@ -126,6 +126,7 @@ public class NewsServlet extends HttpServlet {
       lastSubstring = substrings[i - 1];
       thisSubstring = substrings[i];
       title = thisSubstring.substring(thisSubstring.indexOf(">") + 1, thisSubstring.indexOf("<"));
+      title = title.replace("&#39;", "'");
       linkElement = lastSubstring.substring(lastSubstring.lastIndexOf("href"), lastSubstring.lastIndexOf("\""));
       link = "http://news.google.com" + linkElement.substring(linkElement.indexOf(".") + 1, linkElement.lastIndexOf("\""));
       articleList.add(new Article(title, link));


### PR DESCRIPTION
Quotes in single news titles are presented correctly instead of as '&#39'. 