### PR TITLE
Implement login validation in backend for results page.

### DIFF
--- a/src/main/java/com/google/sps/servlets/ResultsServlet.java
+++ b/src/main/java/com/google/sps/servlets/ResultsServlet.java
@@ -24,7 +24,7 @@ public class ResultsServlet extends HttpServlet {
     Map<String, String> map = new HashMap<>();
     DefaultMustacheFactory mf = new DefaultMustacheFactory();
     Mustache mustache;
-	  if (userService.isUserLoggedIn()) {
+    if (userService.isUserLoggedIn()) {
       String logoutUrl = userService.createLogoutURL("/");
       map.put("key", key);
       map.put("logoutUrl", logoutUrl);

--- a/src/main/java/com/google/sps/servlets/ResultsServlet.java
+++ b/src/main/java/com/google/sps/servlets/ResultsServlet.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.github.mustachejava.DefaultMustacheFactory;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 
 /** Serves the html template used in the results page with a datastore key. */
 @WebServlet("/results")
@@ -17,11 +19,21 @@ public class ResultsServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
     String key = request.getParameter("k");
     Map<String, String> map = new HashMap<>();
-    map.put("key", key);
     DefaultMustacheFactory mf = new DefaultMustacheFactory();
-    Mustache mustache = mf.compile("results.html");
+    Mustache mustache;
+	  if (userService.isUserLoggedIn()) {
+      String logoutUrl = userService.createLogoutURL("/");
+      map.put("key", key);
+      map.put("logoutUrl", logoutUrl);
+      mustache = mf.compile("results.html");
+    } else {
+      String loginUrl = userService.createLoginURL(String.format("/results?k=%s", key));
+      map.put("loginUrl", loginUrl);
+      mustache = mf.compile("results403.html");
+    }
     response.setContentType("text/html;");
     mustache.execute(response.getWriter(), map).flush();
   }

--- a/src/main/resources/results.test
+++ b/src/main/resources/results.test
@@ -1,1 +1,1 @@
-{{key}}
+Key:{{key}}-LogoutURL:{{logoutUrl}}

--- a/src/main/resources/results403.test
+++ b/src/main/resources/results403.test
@@ -1,0 +1,1 @@
+LoginUrl:{{loginUrl}}

--- a/src/main/webapp/styles/modalWindow.css
+++ b/src/main/webapp/styles/modalWindow.css
@@ -21,6 +21,7 @@
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
+  padding: 1vh 1vw;
 }
 
 #pop-up > .close {
@@ -70,6 +71,13 @@
   display: flex;
   align-items: center;
 }
+
+#buttons > .button {
+  font-size: 1.5vh;
+  display: inline-flex;
+  align-items: center;
+}
+
 
 @media (orientation: portrait) {
   #pop-up {

--- a/src/main/webapp/templates/results.html
+++ b/src/main/webapp/templates/results.html
@@ -31,9 +31,8 @@
             <p> Go back to input form</p>
           </div>
         </div>
-        <button id="log-btn" class="hide button"></button>
+        <a id="log-btn" class="hide button" href="{{logoutUrl}}">Log out</a>
         <p id="title">Engage</p>
-        <p id="login-error" class="hide">You are not logged in!</p>
         <div id="progress-bar">
           <div id="bar"></div>
           <div id="progress"></div>
@@ -55,7 +54,6 @@
     <script src="/scripts/civic.js"></script>
     <script src="/scripts/modalMenu.js"></script>
     <script src="/scripts/toggle.js"></script>
-    <script src="/scripts/logButton.js"></script>
     <script src="/scripts/results.js"></script>
   </body>
 </html>

--- a/src/main/webapp/templates/results403.html
+++ b/src/main/webapp/templates/results403.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8">
+    <title>Results 403</title>
+    <link rel="stylesheet" href="/styles/base.css">
+    <link rel="stylesheet" href="/styles/modalWindow.css">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Oswald&display=swap" rel="stylesheet">
+    <script type='module' src='https://unpkg.com/ionicons@5.1.1/dist/ionicons/ionicons.esm.js'></script>
+    <script nomodule='' src='https://unpkg.com/ionicons@5.1.1/dist/ionicons/ionicons.js'></script>
+  </head>
+  <body>
+    <div id="modal-window">
+      <div id="pop-up">
+        <p id="modal-title">Sorry, to access the results page you have to log in.</p>
+        <div id="buttons">
+          <a class="button" href="/">            
+            <ion-icon name="arrow-back-outline"></ion-icon>
+            Go back to input form
+          </a>
+          <a class="button" href="{{loginUrl}}">Log in</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Instead of validating the user after the results page has been served, the user validation happens in the backend. This way the client only receives the information that they are supposed to be seeing. (Copy of #115)